### PR TITLE
Replacing '.vss' with '.metadata'

### DIFF
--- a/vehicle/viss/0100-getVss-success.html
+++ b/vehicle/viss/0100-getVss-success.html
@@ -66,15 +66,15 @@ vehicle.onopen = function() {
 
       // Received full VSS tree
       if (isMetadataSuccessResponse(reqId_0, msg)) {
-        objVssAll = msg.vss;
-        strVssAll = JSON.stringify(msg.vss);
+        objVssAll = msg.metadata;
+        strVssAll = JSON.stringify(msg.metadata);
         //addLogMessage("<br>get vss all = " + strVssAll.substr(1,200));
       }
 
       // Received partial VSS tree
       if (isMetadataSuccessResponse(reqId_1, msg)) {
-        var objVssPart = msg.vss;
-        var strVssPart = JSON.stringify(msg.vss);
+        var objVssPart = msg.metadata;
+        var strVssPart = JSON.stringify(msg.metadata);
         addLogMessage("<br>getMetadata result vss = " + strVssPart);
       }
 


### PR DESCRIPTION
- According to the spec change, '.vss' of JSON object is replaced with '.metadata'