### PR TITLE
Replacing '.vss' with '.metadata' for 0105-getVss-no-path-success.html

### DIFF
--- a/vehicle/viss/0105-getVss-no-path-success.html
+++ b/vehicle/viss/0105-getVss-no-path-success.html
@@ -48,7 +48,7 @@ vehicle.onopen = function() {
       if (isMetadataSuccessResponse(reqId, msg)) {
         //TODO: Response really matches with request?
         //TODO: How to judge if this is engire tree?
-        var vssStr = JSON.stringify(msg.vss).substr(1,3000);
+        var vssStr = JSON.stringify(msg.metadata).substr(1,3000);
         helper_terminate_success("getMetadata response received.");
         addLogMessage("<br>vss = " + vssStr);
       } else {


### PR DESCRIPTION
- According to the spec change, '.vss' of JSON object is replaced with '.metadata'