### PR TITLE
Replacing '.vss' with '.metadata' for vehicle-test-helper.js

### DIFF
--- a/vehicle/viss/vehicle-test-helper.js
+++ b/vehicle/viss/vehicle-test-helper.js
@@ -43,7 +43,7 @@ function isMetadataSuccessResponse( _reqId, _inJson) {
   if (
       _inJson.action === "getMetadata" &&
       _inJson.requestId &&
-      _inJson.vss &&                //'TTL' exists
+      _inJson.metadata &&                //'TTL' exists
       _inJson.error === undefined)  //'error' not exists
   {
     if (_reqId === "" || _reqId === _inJson.requestId) {
@@ -60,7 +60,7 @@ function isMetadataErrorResponse( _reqId, _inJson) {
   if (
       _inJson.action === "getMetadata" &&
       _inJson.requestId &&
-      _inJson.vss === undefined &&  //'vss' not exists
+      _inJson.metadata === undefined &&  //'vss' not exists
       _inJson.error)                //'error' exists
   {
     if (_reqId === "" || _reqId === _inJson.requestId) {


### PR DESCRIPTION
- According to the spec change, '.vss' of JSON object is replaced with '.metadata' for isMetadataSuccessResponse and isMetadataErrorResponse functions