### PR TITLE
Replacing '.vss' with '.metadata' for 0110-getVss-wildcard-success.html

### DIFF
--- a/vehicle/viss/0110-getVss-wildcard-success.html
+++ b/vehicle/viss/0110-getVss-wildcard-success.html
@@ -51,7 +51,7 @@ vehicle.onopen = function() {
       if (isMetadataSuccessResponse(reqId, msg)) {
         //TODO: Need to check returned vss really match with the wildcard path?
 
-        var vssStr = JSON.stringify(msg.vss).substr(1,3000);
+        var vssStr = JSON.stringify(msg.metadata).substr(1,3000);
         helper_terminate_success("getMetadata response received.");
         addLogMessage("<br>vss = " + vssStr);
       } else if (isMetadataErrorResponse(reqId, msg)) {


### PR DESCRIPTION
- According to the spec change, '.vss' of JSON object is replaced with '.metadata'