### PR TITLE
Replacing '.vss' with '.metadata' for 0120-getVss-incorrect-error.html

### DIFF
--- a/vehicle/viss/0120-getVss-incorrect-error.html
+++ b/vehicle/viss/0120-getVss-incorrect-error.html
@@ -48,7 +48,7 @@ vehicle.onopen = function() {
     t.step_func(function() {
 
       if (isMetadataSuccessResponse(reqId, msg)) {
-        var vssStr = JSON.stringify(msg.vss).substr(1,3000);
+        var vssStr = JSON.stringify(msg.metadata).substr(1,3000);
         helper_terminate_failure("metadataSuccessResponse received. Wrong behavior");
         addLogMessage("<br>vss = " + vssStr);
       } else {


### PR DESCRIPTION
- According to the spec change, '.vss' of JSON object is replaced with '.metadata'